### PR TITLE
Bundler 1.0 - install via --deployment flag

### DIFF
--- a/lib/inploy/templates/rails3_push.rb
+++ b/lib/inploy/templates/rails3_push.rb
@@ -47,7 +47,7 @@ module Inploy
         command << "git reset --hard"
         command << "git clean -f -d"
         command << "git submodule update --init"
-        command << "bundle install"
+        command << "bundle install --deployment"
         remote_run command.join(' && ')
       end
 


### PR DESCRIPTION
Install bundled gems into vendor/bundle. This way you don't need to use sudo to install into system-gems.

From the bundler docs: http://gembundler.com/bundle_install.html

Install all dependencies using defaults appropriate for deployment.
$ bundle install --deployment
The --deployment flag activates a number of deployment-friendly conventions:

Isolate all gems into vendor/bundle
Require an up-to-date Gemfile.lock
If bundle package was run, do not fetch gems from rubygems.org. Instead, only use gems in the checked in vendor/cache
