### PR TITLE
Change remote call from sh  to bash

### DIFF
--- a/lib/inploy/dsl.rb
+++ b/lib/inploy/dsl.rb
@@ -74,7 +74,7 @@ module Inploy
     end
 
     def login_shell_wrap(cmd)
-      login_shell ? "\"sh -l -c '#{cmd}'\"" : "'#{cmd}'"
+      login_shell ? "\"bash -l -c '#{cmd}'\"" : "'#{cmd}'"
     end
 
     def secure_copy(src, dest)

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -150,7 +150,7 @@ shared_examples_for "remote update" do
 
   it "should run inploy:local:update task with login_shell" do
     subject.login_shell = true
-    expect_command "ssh #{@ssh_opts} #{@user}@#{@host} \"sh -l -c 'cd #{@path}/#{@application} && rake inploy:local:update RAILS_ENV=#{subject.environment} environment=#{subject.environment}'\""
+    expect_command "ssh #{@ssh_opts} #{@user}@#{@host} \"bash -l -c 'cd #{@path}/#{@application} && rake inploy:local:update RAILS_ENV=#{subject.environment} environment=#{subject.environment}'\""
     subject.remote_update
   end
 


### PR DESCRIPTION
in some distros (like ubuntu)  /bin/sh points to /bin/dash. 

/bin/dash don't support source and [[ ]] commands used by rvm
