### PR TITLE
Fix erros in 1.8.6

### DIFF
--- a/lib/inploy/dsl.rb
+++ b/lib/inploy/dsl.rb
@@ -3,9 +3,11 @@ module Inploy
     module ClassMethods
       def define_callbacks(*callbacks)
         callbacks.each do |callback|
-          define_method callback do |&block|
-            instance_variable_set "@#{callback}", block
-          end
+          class_eval <<-METHOD
+            def #{callback} &block
+              instance_variable_set("@#{callback}", block)
+            end
+          METHOD
         end
       end
     end

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -135,7 +135,7 @@ describe Inploy::Deploy do
 
       it "should exec the commands in all hosts" do
         subject.hosts = ['host0', 'host1', 'host2']
-        3.times.each do |i|
+        3.times do |i|
           expect_command "ssh #{@ssh_opts} #{@user}@host#{i} 'cd #{@path}/#{@application} && rake inploy:local:update RAILS_ENV=#{@environment} environment=#{@environment}'"
         end
         subject.remote_update

--- a/spec/rails3_push_spec.rb
+++ b/spec/rails3_push_spec.rb
@@ -32,7 +32,7 @@ describe Inploy::Deploy do
 
       it "should push git repository and runs the local update on all hosts" do
         subject.hosts = ['host0', 'host1', 'host2']
-        3.times.each do |i|
+        3.times do |i|
           expect_command "git push -f batman@host#{i}:/fakie/path/robin live"
           expect_command "ssh #{@ssh_opts} batman@host#{i} 'cd /fakie/path/robin && git reset --hard && git clean -f -d -e public/system && git submodule update --init && bundle install --deployment'"
           expect_command "ssh #{@ssh_opts} batman@host#{i} 'cd /fakie/path/robin && rake inploy:local:update RAILS_ENV=production environment=production'"


### PR DESCRIPTION
Locaweb still uses Ruby 1.8.6 on shared hosting.
