### PR TITLE
New before_git callback

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -156,6 +156,7 @@ h2. HOOKS
 
 Currently, the following three hooks are available:
 
+- before_git (not called before initial git clone)
 - after_git
 - after_setup
 - before_restarting_server

--- a/lib/inploy/deploy.rb
+++ b/lib/inploy/deploy.rb
@@ -5,7 +5,7 @@ module Inploy
 
     attr_accessor :repository, :user, :application, :hosts, :path, :app_folder, :ssh_opts, :branch, :environment, :port, :skip_steps, :cache_dirs, :sudo, :login_shell, :bundler_opts
 
-    define_callbacks :after_git, :after_setup, :before_restarting_server
+    define_callbacks :before_git, :after_git, :after_setup, :before_restarting_server
 
     def initialize
       self.server = :passenger
@@ -62,6 +62,7 @@ module Inploy
     end
 
     def remote_reset(params)
+      callback :before_git
       remote_run "cd #{application_path} && git reset --hard #{params[:to]}"
       callback :after_git
     end
@@ -72,6 +73,7 @@ module Inploy
     end
 
     def update_code
+      callback :before_git
       run "git pull origin #{branch}"
       callback :after_git
     end

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -205,6 +205,14 @@ describe Inploy::Deploy do
         subject.remote_reset :to => commit
       end
 
+      it "should call the before_git callback" do
+        subject.before_git do
+          rake "test_before_git"
+        end
+        expect_command("rake test_before_git").ordered
+        subject.remote_reset :to => "fa3ed118970d8ddb0655be94b4c85d996c695476"
+      end
+
       it "should call the after_git callback" do
         subject.after_git do
           rake "test_after_git"
@@ -215,6 +223,14 @@ describe Inploy::Deploy do
     end
     
     context "on code update" do
+      it "should call the before_git callback" do
+        subject.before_git do
+          rake "test_before_git"
+        end
+        expect_command("rake test_before_git").ordered
+        subject.update_code
+      end 
+
       it "should call the after_git callback" do
         subject.after_git do
           rake "test_after_git"


### PR DESCRIPTION
The after_git callback from a recent pull request is useful to e.g. copy files like database.yml from a template directory on the server after git has cloned/updated/reset code. However, you will bump into trouble if you use it overwrite a file which is in the git repo (e.g. an initializer). Subsequent updates might fail since the local working tree is dirty.

An easy fix for this is to issue a "git checkout ." before the git update/reset happens. (It's not useful nor easy to impliment before a git clone.) But instead of hardcoding it, I've added a bro for the after_git callback - the before_git callback. The default behavior is therefore not altered at all.

(The second commit is a fix for a faulty yet passing test of the after_git callback.)
