### PR TITLE
Removed unnecessary shell command evaluation.

### DIFF
--- a/lib/inploy/deploy.rb
+++ b/lib/inploy/deploy.rb
@@ -81,7 +81,7 @@ module Inploy
     private
 
     def checkout
-      branch.eql?("master") ? "" : "&& $(git branch | grep -vq #{branch}) && git checkout -f -b #{branch} origin/#{branch}"
+      branch.eql?("master") ? "" : "&& git checkout -f -b #{branch} origin/#{branch}"
     end
 
     def bundle


### PR DESCRIPTION
This belongs to #37.

Two things make the $() command evaluation unnecessary:

1) Has no effect. Providing a non existing branch still allows the last command in the chain to execute.
2) Fails in combination with login_shell=true, because the $() gets evaluated locally and not on the server, as it was probably intended.
