### PR TITLE
Fix for delayed_job not restarting.

### DIFF
--- a/lib/inploy/deploy.rb
+++ b/lib/inploy/deploy.rb
@@ -95,7 +95,7 @@ module Inploy
       migrate_database
       update_crontab
       run "rm -R -f public/assets" if jammit_is_installed?
-      run "RAILS_ENV=#{environment} script/delayed_job restart" if file_exists?("script/delayed_job")
+      run "script/delayed_job -e #{environment} restart" if file_exists?("script/delayed_job")
       rake_if_included "more:parse"
       run "compass compile" if file_exists?("config/compass.rb")
       rake_if_included "barista:brew"

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -396,14 +396,14 @@ shared_examples_for "local update" do
   it "should restart the delayed job worker if script/delayed_job exist" do
     subject.environment = "env9"
     file_exists "script/delayed_job"
-    expect_command "RAILS_ENV=env9 script/delayed_job restart"
+    expect_command "script/delayed_job -e env9 restart"
     subject.local_update
   end
 
   it "should not restart the delayed job worker if script/delayed_job doesnt exist" do
     subject.environment = "env9"
     file_doesnt_exists "script/delayed_job"
-    dont_accept_command "RAILS_ENV=env9 script/delayed_job restart"
+    dont_accept_command "script/delayed_job -e env9 restart"
     subject.local_update
   end
 


### PR DESCRIPTION
With "login_shell = true", delayed_job is not being restarted even though the corresponding run is being executed. The problem is fixed by no longer passing the Rails environment by setting the RAILS_ENV variable but using the "-e" option script/delayed_job implements precisely for that.

This is a very nasty issue since not restarting delayed_job after a deploy may cause major problems. A change of a mailer method signature for instance would cause every new job to fail.
