### PR TITLE
Fix the fix: Use RAILS_ENV after command rather than the defunct "-e" option.

### DIFF
--- a/lib/inploy/deploy.rb
+++ b/lib/inploy/deploy.rb
@@ -95,7 +95,7 @@ module Inploy
       migrate_database
       update_crontab
       run "rm -R -f public/assets" if jammit_is_installed?
-      run "script/delayed_job -e #{environment} restart" if file_exists?("script/delayed_job")
+      run "script/delayed_job restart RAILS_ENV=#{environment}" if file_exists?("script/delayed_job")
       rake_if_included "more:parse"
       run "compass compile" if file_exists?("config/compass.rb")
       rake_if_included "barista:brew"

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -396,14 +396,14 @@ shared_examples_for "local update" do
   it "should restart the delayed job worker if script/delayed_job exist" do
     subject.environment = "env9"
     file_exists "script/delayed_job"
-    expect_command "script/delayed_job -e env9 restart"
+    expect_command "script/delayed_job restart RAILS_ENV=env9"
     subject.local_update
   end
 
   it "should not restart the delayed job worker if script/delayed_job doesnt exist" do
     subject.environment = "env9"
     file_doesnt_exists "script/delayed_job"
-    dont_accept_command "script/delayed_job -e env9 restart"
+    dont_accept_command "script/delayed_job restart RAILS_ENV=env9"
     subject.local_update
   end
 


### PR DESCRIPTION
The "fix" from f3f1b5d03f is no good since delay_job is not honoring the "-e" option anymore. However, setting the RAILS_ENV after the command rather than before does the trick.

Sorry for the last commit, I have missed the deprecation note in the cascade of deployment output
