### PR TITLE
Raise error if git fails.

### DIFF
--- a/lib/inploy/deploy.rb
+++ b/lib/inploy/deploy.rb
@@ -74,7 +74,7 @@ module Inploy
 
     def update_code
       callback :before_git
-      run "git pull origin #{branch}"
+      raise "ERROR: git pull failed with error status = #{$?}" unless run "git pull origin #{branch}"
       callback :after_git
     end
 


### PR DESCRIPTION
Deploy should halt if git fails. Otherwise at a glance it looks like the the deployment succeeded.
